### PR TITLE
Fix spelling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: r
+dist: trusty
+cache: packages
+r_packages:
+- covr
+after_success:
+- R -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,4 @@ Imports:
 Suggests:
     testthat,
     proxy
-Collate:
-    'RcppExports.R'
-    'proxy.R'
 RoxygenNote: 6.1.1

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -1,22 +1,25 @@
-#' Compute similiarty/distance between raws or columns of large matrices
+#' Compute similarity/distance between rows or columns of large matrices
 #'
 #' Fast similarity/distance computation function for large sparse matrices. You
-#' can floor small similairty value to to save computation time and storage
+#' can floor small similarity value to to save computation time and storage
 #' space by an arbitrary threashold (\code{min_simil}) or rank (\code{rank}).
 #' Please increase the numbner of threads for better perfromance using
 #' \code{\link[RcppParallel]{setThreadOptions}}.
+#'
 #' @param x a \link{matrix} or \link{Matrix} object
 #' @param y if a \link{matrix} or \link{Matrix} object is provided, proximity
 #'   between documents or features in \code{x} and \code{y} is computed.
-#' @param margin integer indicating margin of similiarty/distance computation. 1
+#' @param margin integer indicating margin of similarity/distance computation. 1
 #'   indicates rows or 2 indicates columns.
 #' @param method method to compute similarity or distance
-#' @param min_simil the minimum similiarty value to be recoded.
-#' @param rank an integer value specifying top-n most similiarty values to be
+#' @param min_simil the minimum similarity value to be recoded.
+#' @param rank an integer value specifying top-n most similarity values to be
 #'   recorded.
 #' @param p weight for minkowski distance
+#'
 #' @import methods Matrix
 #' @importFrom RcppParallel RcppParallelLibs
+#'
 #' @export
 #' @examples
 #' mt <- Matrix::rsparsematrix(100, 100, 0.01)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/man/simil.Rd
+++ b/man/simil.Rd
@@ -3,7 +3,7 @@
 \name{simil}
 \alias{simil}
 \alias{dist}
-\title{Compute similiarty/distance between raws or columns of large matrices}
+\title{Compute similarity/distance between rows or columns of large matrices}
 \usage{
 simil(x, y = NULL, margin = 1, method = c("cosine", "correlation",
   "jaccard", "ejaccard", "dice", "edice", "hamman", "simple matching",
@@ -19,21 +19,21 @@ dist(x, y = NULL, margin = 1, method = c("euclidean", "chisquared",
 \item{y}{if a \link{matrix} or \link{Matrix} object is provided, proximity
 between documents or features in \code{x} and \code{y} is computed.}
 
-\item{margin}{integer indicating margin of similiarty/distance computation. 1
+\item{margin}{integer indicating margin of similarity/distance computation. 1
 indicates rows or 2 indicates columns.}
 
 \item{method}{method to compute similarity or distance}
 
-\item{min_simil}{the minimum similiarty value to be recoded.}
+\item{min_simil}{the minimum similarity value to be recoded.}
 
-\item{rank}{an integer value specifying top-n most similiarty values to be
+\item{rank}{an integer value specifying top-n most similarity values to be
 recorded.}
 
 \item{p}{weight for minkowski distance}
 }
 \description{
 Fast similarity/distance computation function for large sparse matrices. You
-can floor small similairty value to to save computation time and storage
+can floor small similarity value to to save computation time and storage
 space by an arbitrary threashold (\code{min_simil}) or rank (\code{rank}).
 Please increase the numbner of threads for better perfromance using
 \code{\link[RcppParallel]{setThreadOptions}}.


### PR DESCRIPTION
Konbanwa Watanabe-san!

Thanks for making proxyC! You saved me a lot of implementation time by creating this package.

In this pull request, I made the following suggestions:
* I fixed some small spelling errors in the documentation (f9f8469).
* I removed the Collate: section from the DESCRIPTION as it is not necessary (7d24d6f).
* I added travis and appveyor files (52f4849, 0aacde9). You will need to activate travis and appveyor yourself if you wish to make use of it.

I noticed that the doi listed in the DESCRIPTION does not work ─ it seems the article you are citing does not have a doi. 