### PR TITLE
Bring back the hamming distance!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,31 +1,39 @@
-# v0.2.0
+# proxyC 0.2.0
 
-- Add the `diag` argument to compute similarity/distance only for corresponding rows or columns.
-- Correct the chi-squared distance to match `stats::chisq.test()`.
-- Fix a bug in pairwise similarity/distance computation when `drop0 = TRUE`.
+## New features
+- Added a `diag` argument to compute similarity/distance only for corresponding rows or columns (#13).
+- Added a `smooth` parameter to chisquared and kullback leibler distances to solve negative values in sparse matrices (#15).
+- Added the hamming distance (#18)
 
-# v0.1.5
+## Bug fixes
+- Fixed the chi-squared distance to match `stats::chisq.test()` (#14).
+- Fixed a bug in pairwise similarity/distance computation when `drop0 = TRUE` (#17).
 
-## New feature
 
-- Add the drop0 argument to address the floating point precision issue.
+# proxyC 0.1.5
 
-## Bug fix
+## New features
 
-- The digit argument is now passed to `dist()`.
+- Add the `drop0` argument to address the floating point precision issue (#10).
 
-# v0.1.4
+## Bug fixes
 
-## New feature
+- The digit argument is now passed to `dist()` (#11).
 
-- Add `rowSds()`, `colSds()`, `rowZeros()` and `colZeros()`.
 
-# v0.1.3
+# proxyC 0.1.4
 
-## Bug fix
+## New features
 
-- No longer assumes symmetry of resulting matrix when `x != y`.
+- Added `rowSds()`, `colSds()`, `rowZeros()` and `colZeros()` (#9).
 
-## New feature
 
-- Add the digits argument to correct rounding errors in C++ (#5).
+# proxyC 0.1.3
+
+## Bug fixes
+
+- No longer assumes symmetry of resulting matrix when `x != y` (#4).
+
+## New features
+
+- Added the `digits` argument to correct rounding errors in C++ (#5).

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -50,7 +50,7 @@ simil <- function(x, y = NULL, margin = 1,
 #' dist(mt, method = "euclidean")[1:5, 1:5]
 dist <- function(x, y = NULL, margin = 1,
                  method = c("euclidean", "chisquared", "kullback",
-                            "manhattan", "maximum", "canberra", "minkowski"),
+                            "manhattan", "maximum", "canberra", "minkowski", "hamming"),
                  p = 2, smooth = 0, drop0 = FALSE, diag = FALSE, digits = 14) {
 
     method <- match.arg(method)
@@ -64,7 +64,7 @@ proxy <- function(x, y = NULL, margin = 1,
                   method = c("cosine", "correlation", "jaccard", "ejaccard",
                              "dice", "edice", "hamman", "simple matching", "faith",
                              "euclidean", "chisquared", "kullback",
-                             "manhattan", "maximum", "canberra", "minkowski"),
+                             "manhattan", "maximum", "canberra", "minkowski", "hamming"),
                   p = 2, smooth = 0, min_proxy = NULL, rank = NULL, drop0 = FALSE, diag = FALSE, digits = 14) {
 
     method <- match.arg(method)
@@ -147,7 +147,7 @@ proxy <- function(x, y = NULL, margin = 1,
             method = match(method, c("cosine", "correlation", "ejaccard", "edice",
                                      "hamman", "simple matching", "faith",
                                      "euclidean", "chisquared", "kullback", "manhattan",
-                                     "maximum", "canberra", "minkowski")),
+                                     "maximum", "canberra", "minkowski", "hamming")),
             rank = rank,
             limit = min_proxy,
             weight = weight,

--- a/man/simil.Rd
+++ b/man/simil.Rd
@@ -23,7 +23,7 @@ dist(
   y = NULL,
   margin = 1,
   method = c("euclidean", "chisquared", "kullback", "manhattan", "maximum", "canberra",
-    "minkowski"),
+    "minkowski", "hamming"),
   p = 2,
   smooth = 0,
   drop0 = FALSE,

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -72,6 +72,10 @@ double dist_manhattan(colvec& col_i, colvec& col_j) {
     return accu(abs(col_i - col_j));
 }
 
+double dist_hamming(colvec& col_i, colvec& col_j) {
+    return accu(col_i != col_j);
+}
+
 double dist_maximum(colvec& col_i, colvec& col_j) {
     return accu(max(abs(col_i - col_j)));
 }
@@ -171,6 +175,9 @@ struct pairWorker : public Worker {
                     break;
                 case 14:
                     simil = dist_minkowski(col_i, col_j, weight);
+                    break;
+                case 15:
+                    simil = dist_hamming(col_i, col_j);
                     break;
                 }
                 //Rcout << "simil=" << simil << "\n";

--- a/tests/testthat/test-dist.R
+++ b/tests/testthat/test-dist.R
@@ -1,5 +1,5 @@
 require(Matrix)
-mat_test <- rsparsematrix(100, 100, 0.5)
+mat_test <- rsparsematrix(100, 90, 0.5)
 
 test_dist <- function(x, method, margin, ignore_upper = FALSE, ...) {
     # test with only x

--- a/tests/testthat/test-dist.R
+++ b/tests/testthat/test-dist.R
@@ -108,3 +108,22 @@ test_that("test kullback kullback distance", {
         entropy::KL.empirical(dmat[,2] + 1, dmat[,1] + 1)
     )
 })
+
+test_that("test hamming distance", {
+    new_mat_test <- rsparsematrix(100, 80, 1, rand.x = function(x) sample.int(10, x, replace = TRUE))
+    dmat <- as.matrix(proxyC::dist(new_mat_test, method = "hamming"))
+    dmat_manual <-
+        sapply(seq_len(nrow(new_mat_test)), function(i) {
+            rowSums(sweep(new_mat_test, 2, new_mat_test[i, ], "!="))
+        })
+    expect_equal(
+        dmat,
+        dmat_manual,
+        check.attributes = FALSE
+    )
+    expect_equal(
+        mean(dmat[!diag(nrow(dmat))]),
+        .9 * nrow(new_mat_test), # thanks to rand.x function, there's a 10% chance that values from different rows will match
+        tolerance = 1
+    )
+})

--- a/tests/testthat/test-dist.R
+++ b/tests/testthat/test-dist.R
@@ -110,7 +110,7 @@ test_that("test kullback leibler distance", {
 })
 
 test_that("test hamming distance", {
-    new_mat_test <- rsparsematrix(100, 80, 1, rand.x = function(x) sample.int(10, x, replace = TRUE))
+    new_mat_test <- rsparsematrix(100, 90, 1, rand.x = function(x) sample.int(10, x, replace = TRUE))
     dmat <- as.matrix(proxyC::dist(new_mat_test, method = "hamming"))
     dmat_manual <-
         sapply(seq_len(nrow(new_mat_test)), function(i) {

--- a/tests/testthat/test-dist.R
+++ b/tests/testthat/test-dist.R
@@ -91,7 +91,7 @@ test_that("test chisquared distance", {
     )
 })
 
-test_that("test kullback kullback distance", {
+test_that("test kullback leibler distance", {
     skip_if_not_installed("entropy")
     smat <- rsparsematrix(10, 2, 0.5, rand.x = sample.int)
     expect_equal(

--- a/tests/testthat/test-simil.R
+++ b/tests/testthat/test-simil.R
@@ -1,5 +1,5 @@
 require(Matrix)
-mat_test <- rsparsematrix(100, 100, 0.5)
+mat_test <- rsparsematrix(100, 90, 0.5)
 
 test_simil <- function(x, method, margin, ignore_upper = FALSE, ignore_diag = TRUE, ...) {
     # test with only x


### PR DESCRIPTION
Fairly straight forward PR: I added back the hamming distance and wrote a small test. Since proxy doesn't support computing the hamming distance, I compute it manually by sapply-sweeping over the input matrix.

Some minor fixes to the NEWS.md are also included.