### PR TITLE
Change for Matrix v1.4-2 or later

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+- Change how `x` and `y` are coerced to dgCMatrix for Matrix v1.4-2
+
 # proxyC 0.2.3
 
 - Change "hamman" to "hamann" in `simil()` to correct misspelling (#26).

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -38,6 +38,7 @@
 #'   \item `ejaccard`: the real value version of `jaccard`
 #'   \item `dice`: Dice coefficient
 #'   \item `edice`: the real value version of `dice`
+#'   \item `hamann`: Hamann similarity
 #'   \item `faith`: Faith similarity
 #'   \item `simple matching`: the percentage of common elements
 #' }

--- a/R/proxy.R
+++ b/R/proxy.R
@@ -78,14 +78,16 @@ proxy <- function(x, y = NULL, margin = 1,
 
     method[method == "hamman"] <- "hamann" # for transition
     method <- match.arg(method)
-    x <- as(x, "dgCMatrix")
+    #x <- as(x, "dgCMatrix")
+    x <- as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix") # for Matrix v1.4-2 or later
 
     symm <- is.null(y)
 
     if (is.null(y)) {
         y <- x
     } else {
-        y <- as(y, "dgCMatrix")
+        #y <- as(y, "dgCMatrix")
+        y <- as(as(as(y, "CsparseMatrix"), "generalMatrix"), "dMatrix") # for Matrix v1.4-2 or later
     }
     if (!margin %in% c(1, 2))
         stop("Matrgin must be 1 (row) or 2 (column)")

--- a/man/simil.Rd
+++ b/man/simil.Rd
@@ -87,6 +87,7 @@ Available methods for similarity:
   \item `ejaccard`: the real value version of `jaccard`
   \item `dice`: Dice coefficient
   \item `edice`: the real value version of `dice`
+  \item `hamann`: Hamann similarity
   \item `faith`: Faith similarity
   \item `simple matching`: the percentage of common elements
 }


### PR DESCRIPTION
Based on the email notice by the Matrix authors

> 
> As discussed in Martin's thread from Aug 12
> 
>     Matrix 1.4-2 needs adaption in your CRAN package
> 
> as(<matrix>, "dgCMatrix") has been _un_deprecated, and as(<matrix>, "dMatrix") is actually not backwards compatible.  So my recommendation above should really
> be revised.  If you are sure that that 'x' and 'y' are traditional matrices,
> then you can do:
> 
> > x <- as(x, "dgCMatrix")
> > y <- as(y, "dgCMatrix")
> 
> If you don't know anything about 'x' and 'y', then use the following,
> which is safe _and_ backwards compatible:
> 
> > x <- as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix")
> > y <- as(as(as(y, "CsparseMatrix"), "generalMatrix"), "dMatrix") 
> 