### PR TITLE
Fix mkl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: proxyC
 Type: Package
 Title: Computes Proximity in Large Sparse Matrices
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person("Kohei", "Watanabe", email = "watanabe.kohei@gmail.com", role = c("cre", "aut", "cph"), 
            comment = c(ORCID = "0000-0001-6519-5265")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# proxyC 0.5.2
+
+## Bug fixes
+
+- Update tests to pass CRAN check with Intel MKL.
+
 # proxyC 0.5.1
 
 ## Bug fixes

--- a/tests/testthat/test-crossprod.R
+++ b/tests/testthat/test-crossprod.R
@@ -19,7 +19,7 @@ test_that("test crossprod", {
     # with min_prod
     prod1_min <- proxyC:::crossprod(mat1, mat2, min_prod = 1.0)
     prod2_min <- prod2
-    prod2_min[prod2_min <= 1.0] <- 0.0
+    prod2_min[prod2_min < 1.0] <- 0.0
 
     expect_equal(
         as.matrix(prod1_min), as.matrix(prod2_min),
@@ -49,7 +49,7 @@ test_that("test tcrossprod", {
     # with min_prod
     prod1_min <- proxyC:::tcrossprod(mat1, mat2, min_prod = 1.0)
     prod2_min <- prod2
-    prod2_min[prod2_min <= 1.0] <- 0.0
+    prod2_min[prod2_min < 1.0] <- 0.0
 
     expect_equal(
         as.matrix(prod1_min), as.matrix(prod2_min),


### PR DESCRIPTION
v0.5.1 was failing CRAN checks with Intel MKL but it was simply due to wrong test conditions. Nothing specifically about MLK. After resubmission as v0.5.2, it passed the checks.